### PR TITLE
Update to Jest 26.x

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
 registry = https://registry.npmjs.org
 access = public
 scope = "@fireeye"
+package-lock=false

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "serverless"
   ],
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "test": "npx jest"
@@ -25,22 +25,25 @@
     "lambda-wrapper": "^0.3.0"
   },
   "devDependencies": {
-    "eslint": "^6.8.0",
-    "eslint-config-airbnb-base": "^14.1.0",
-    "eslint-config-prettier": "^6.10.0",
-    "eslint-plugin-import": "^2.20.1",
-    "eslint-plugin-jest": "^23.8.2",
-    "jest": "^25.1.0",
-    "jest-cli": "^25.1",
-    "jest-config": "^25.1",
-    "jest-runtime": "^25.1",
-    "@jest/console": "^25.1",
-    "serverless": "^1.66.0"
+    "eslint": "^7.6.0",
+    "eslint-config-airbnb-base": "^14.2.0",
+    "eslint-config-prettier": "^6.11.0",
+    "eslint-plugin-import": "^2.22.0",
+    "eslint-plugin-jest": "^23.20.0",
+    "jest": "^26.2.2",
+    "jest-cli": "^26.2.2",
+    "jest-config": "^26.2.2",
+    "jest-runtime": "^26.2.2",
+    "@jest/console": "^26.2.0",
+    "serverless": "^1.77.1"
   },
   "peerDependencies": {
-    "jest-environment-node": "23.x || 24.x || 25.x",
+    "jest-environment-node": ">= 23.x",
     "serverless": ">=1.46"
   },
+  "contributors": [
+    "Doug McCall <dhm116@gmail.com>"
+  ],
   "jest": {
     "collectCoverage": true,
     "coverageReporters": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-environment-serverless",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": "FireEye, Inc.",
   "repository": {
     "type": "git",

--- a/src/__tests__/serverless_environment.test.js
+++ b/src/__tests__/serverless_environment.test.js
@@ -33,10 +33,10 @@ describe('ServerlessEnvironment', () => {
 
     env1.fakeTimers.useFakeTimers();
 
-    const timer1 = env1.global.setTimeout(() => { }, 0);
-    const timer2 = env1.global.setInterval(() => { }, 0);
+    const timer1 = env1.global.setTimeout(() => {}, 0);
+    const timer2 = env1.global.setInterval(() => {}, 0);
 
-    [timer1, timer2].forEach(timer => {
+    [timer1, timer2].forEach((timer) => {
       expect(timer.id).toBeDefined();
       expect(typeof timer.ref).toBe('function');
       expect(typeof timer.unref).toBe('function');
@@ -48,14 +48,14 @@ describe('ServerlessEnvironment', () => {
     const env1 = new ServerlessEnvironment(config);
 
     // Verify updated config properties
-    ['setupFiles', 'coveragePathIgnorePatterns'].forEach(field => {
+    ['setupFiles', 'coveragePathIgnorePatterns'].forEach((field) => {
       expect(config).toHaveProperty(field);
       expect(Array.isArray(config[field])).toBeTruthy();
     });
 
     expect(env1.global.ServerlessWrapper).toBeDefined();
     // Verify global context properties
-    ['Serverless', 'rootDir', 'serverless'].forEach(field =>
+    ['Serverless', 'rootDir', 'serverless'].forEach((field) =>
       expect(env1.global.ServerlessWrapper).toHaveProperty(field)
     );
     expect(env1.global.ServerlessWrapper.Serverless).toBe(Serverless);
@@ -120,7 +120,10 @@ describe('ServerlessEnvironment', () => {
 
       await slsEnv.setup();
 
-      new Runtime(config, slsEnv, context.resolver, context.hasteFS);
+      const runtime = new Runtime(config, slsEnv, context.resolver, context.hasteFS);
+      // Jest 25.2 branch no longer auto-imports setupFiles when creating
+      // a new Runtime >:(
+      config.setupFiles.forEach((path) => runtime.requireActual(path));
 
       // eslint-disable-next-line prefer-destructuring
       LambdaWrapper = slsEnv.global.LambdaWrapper;
@@ -139,8 +142,7 @@ describe('ServerlessEnvironment', () => {
 
     describe('setEnv', () => {
       it('uses the supplied Serverless instance if provided', async () => {
-        slsEnv.global.ServerlessWrapper.serverless.service.functions.hello.environment.testEnvVar =
-          'some value';
+        slsEnv.global.ServerlessWrapper.serverless.service.functions.hello.environment.testEnvVar = 'some value';
 
         await LambdaWrapper.getWrapper('hello');
 


### PR DESCRIPTION
- Updates Jest to 26.x
- Supports Serverless 1.77
- Drops support for Node 8 (due to Jest 26)

I doubt https://github.com/fireeye/jest-environment-serverless/pull/15 will ever be merged in